### PR TITLE
Add expiry time to the response

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,8 @@ Get Started
 
     class MSKTokenProvider():
         def token(self):
-            return MSKAuthTokenProvider.generate_auth_token('<my aws region>')
+            token, _ = MSKAuthTokenProvider.generate_auth_token('<my aws region>')
+            return token
 
     tp = MSKTokenProvider()
 
@@ -89,11 +90,10 @@ Get Started
     from confluent_kafka import Consumer
     import socket
     import time
-    import traceback
     from aws_msk_iam_sasl_signer import MSKAuthTokenProvider
 
     def oauth_cb(oauth_config):
-        return MSKAuthTokenProvider.generate_auth_token("<my aws region>"), time.time() + 900.0
+        return MSKAuthTokenProvider.generate_auth_token("<my aws region>")
 
     c = Consumer({
         "debug": "all",
@@ -128,7 +128,7 @@ Get Started
 
     class MSKTokenProvider():
         def token(self):
-            oauth2_token = MSKAuthTokenProvider.generate_auth_token_from_profile('<your aws region>', '<named_profile>')
+            oauth2_token, _ = MSKAuthTokenProvider.generate_auth_token_from_profile('<your aws region>', '<named_profile>')
             return oauth2_token
 
 * In order to use a role arn to generate token, replace the token() function with code below :
@@ -137,7 +137,7 @@ Get Started
 
     class MSKTokenProvider():
         def token(self):
-            oauth2_token = MSKAuthTokenProvider.generate_auth_token_from_role_arn('<your aws region>', '<role_arn>')
+            oauth2_token, _ = MSKAuthTokenProvider.generate_auth_token_from_role_arn('<your aws region>', '<role_arn>')
             return oauth2_token
 
 
@@ -147,7 +147,7 @@ Get Started
 
     class MSKTokenProvider():
         def token(self):
-            oauth2_token = MSKAuthTokenProvider.generate_auth_token_from_credentials_provider('<your aws region>', '<your_credentials_provider')
+            oauth2_token, _ = MSKAuthTokenProvider.generate_auth_token_from_credentials_provider('<your aws region>', '<your_credentials_provider')
             return oauth2_token
 
 

--- a/aws_msk_iam_sasl_signer/cli.py
+++ b/aws_msk_iam_sasl_signer/cli.py
@@ -41,14 +41,14 @@ def execute(ctx, region, aws_profile, role_arn, sts_session_name):
     validate_options(ctx)
 
     if aws_profile:
-        token = generate_auth_token_from_profile(region, aws_profile)
+        response = generate_auth_token_from_profile(region, aws_profile)
     elif role_arn:
-        token = generate_auth_token_from_role_arn(region, role_arn,
-                                                  sts_session_name)
+        response = generate_auth_token_from_role_arn(region, role_arn,
+                                                     sts_session_name)
     else:
-        token = generate_auth_token(region)
+        response = generate_auth_token(region)
 
-    click.echo(token)
+    click.echo(response)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Adding expiry time in ms passes expiration time to the librd based kafka clients so that they can determine when to refresh the token. I have tested this with confluent-kafka and updated the ReadMe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->


### Testing Done

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
