### PR TITLE
Fix expiry_ms to be in UTC on all TZ hosts

### DIFF
--- a/aws_msk_iam_sasl_signer/MSKAuthTokenProvider.py
+++ b/aws_msk_iam_sasl_signer/MSKAuthTokenProvider.py
@@ -3,7 +3,7 @@
 
 import base64
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlparse
 
 import boto3
@@ -250,8 +250,11 @@ def __get_expiration_time_ms(request):
     # Parse the signed request
     parsed_url = urlparse(request.url)
     parsed_ul_params = parse_qs(parsed_url.query)
-    signing_time = datetime.strptime(parsed_ul_params['X-Amz-Date'][0],
-                                     "%Y%m%dT%H%M%SZ")
+    parsed_signing_time = datetime.strptime(parsed_ul_params['X-Amz-Date'][0],
+                                            "%Y%m%dT%H%M%SZ")
+
+    # Make the datetime object timezone-aware
+    signing_time = parsed_signing_time.replace(tzinfo=timezone.utc)
 
     # Convert the Unix timestamp to milliseconds
     expiration_timestamp_seconds = int(

--- a/tests/test_auth_token_provider.py
+++ b/tests/test_auth_token_provider.py
@@ -4,7 +4,7 @@
 """Tests for `aws-msk-iam-sasl-signer-python` package."""
 import base64
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
@@ -344,9 +344,12 @@ class TestGenerateAuthToken(unittest.TestCase):
         self.assertIsNotNone(query_params["X-Amz-Signature"][0])
         date_obj = datetime.strptime(query_params["X-Amz-Date"][0],
                                      "%Y%m%dT%H%M%SZ")
-        self.assertTrue(date_obj < datetime.utcnow())
+        current_utc_time = datetime.utcnow()
+
+        self.assertTrue(date_obj < current_utc_time)
 
         self.assertTrue(query_params["User-Agent"][0].startswith(LIB_NAME))
         actual_expiration_ms = 1000 * (
-                int(query_params["X-Amz-Expires"][0]) + date_obj.timestamp())
+                int(query_params["X-Amz-Expires"][0])
+                + date_obj.replace(tzinfo=timezone.utc).timestamp())
         self.assertEqual(expiry_ms, actual_expiration_ms)


### PR DESCRIPTION
### Summary

This PR fixes the issue where on hosts that are in different timezones, the expiry_ms translates to non-utc and gives out an incorrect expiry_ms time.

* On Linux instance with UTC TZ
```
aws_msk_get_auth_token --region us-east-1
('<token>', 1698265893000)
```

* On Mac with PDT TZ

```
aws_msk_get_auth_token --region us-east-1
('<token>', 1698265893000)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->


### Testing Done

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
