### PR TITLE
Removes `tests` folder from published packages in PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     include_package_data=True,
     keywords="aws-msk-iam-sasl-signer-python",
     name="aws-msk-iam-sasl-signer-python",
-    packages=find_packages(exclude=['*tests*']),
+    packages=find_packages(exclude=['tests*']),
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/aws/aws-msk-iam-sasl-signer-python",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     include_package_data=True,
     keywords="aws-msk-iam-sasl-signer-python",
     name="aws-msk-iam-sasl-signer-python",
-    packages=find_packages(),
+    packages=find_packages(exclude=['*tests*']),
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/aws/aws-msk-iam-sasl-signer-python",


### PR DESCRIPTION
### Summary

This package currently submits the `tests` folder to global `site-packages`. This can cause issues when IDEs are searching for tests across the global module namespace. 

![Screenshot 2023-11-23 at 13 11 44](https://github.com/aws/aws-msk-iam-sasl-signer-python/assets/122354532/0291d03f-9741-4964-a358-6d224792f528)

This PR excludes the `tests` folder using the `exclude=` parameter in `find_packages`

**Reference:**
https://stackoverflow.com/questions/61274967/why-cant-i-exclude-tests-directory-from-my-python-wheel-using-exclude

### Testing Done

None

### Related Issues

### PR Overview

- [x] This PR is backwards compatible [y]
- [x] This PR changes the current API [n]
