### PR TITLE
Allow this to be installed on python3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,13 @@ test_requirements = [
 
 setup(
     author="Amazon Managed Streaming for Apache Kafka",
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -54,6 +55,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/aws/aws-msk-iam-sasl-signer-python",
-    version="1.0.0",
+    version="1.0.1",
     zip_safe=False,
 )


### PR DESCRIPTION
### Summary
The tooling appears to work fine on python3.7 and the tox / github actions tests target 3.7 so this should be "safe". As currently published, you cannot install this package on python3.7 environments:

```
$ pip install aws-msk-iam-sasl-signer-python==1.0.0
ERROR: Ignored the following versions that require a different python version: 1.0.0 Requires-Python >=3.8
ERROR: Could not find a version that satisfies the requirement aws-msk-iam-sasl-signer-python==1.0.0
ERROR: No matching distribution found for aws-msk-iam-sasl-signer-python==1.0.0
```

### Testing Done
Verified producing and consuming works from py3.7

```
$ cat confluent_msk_producer.py
from aws_msk_iam_sasl_signer import MSKAuthTokenProvider
from confluent_kafka import Producer
import time

producer = Producer({"bootstrap.servers": "the-bootstrap-server-string", "security.protocol": "SASL_SSL", "sasl.mechanism": "OAUTHBEARER", "oauth_cb": lambda x: MSKAuthTokenProvider.generate_auth_token("us-west-2")})
while True:
 msg = "Sending from py3.7"
 print(msg)
 producer.produce('dpopes-iam-1', msg)
 time.sleep(1)
 producer.flush()

[...]

$ python confluent_msk_producer.py
Sending from py3.7
Sending from py3.7
Sending from py3.7
Sending from py3.7
Sending from py3.7
^CTraceback (most recent call last):
  File "confluent_producer.py", line 10, in <module>
    time.sleep(1)
KeyboardInterrupt
```

```
$ cat confluent_msk_consumer.py
from aws_msk_iam_sasl_signer import MSKAuthTokenProvider
from confluent_kafka import Consumer
import time

consumer = Consumer({"bootstrap.servers": "the-bootstrap-server-string", "security.protocol": "SASL_SSL", "sasl.mechanism": "OAUTHBEARER", "oauth_cb": lambda x: MSKAuthTokenProvider.generate_auth_token("us-west-2"), "group.id": "mygroupid"})
consumer.subscribe(['dpopes-iam-1'])
while True:
 msg = consumer.poll(1)
 if msg:
  print("running on py37 received: {}".format(str(msg.value())))

[...]
$ python confluent_msk_consumer.py

running on py37 received: b'Sending from py3.7'
running on py37 received: b'Sending from py3.7'
running on py37 received: b'Sending from py3.7'
running on py37 received: b'Sending from py3.7'
running on py37 received: b'Sending from py3.7'
^CTraceback (most recent call last):
  File "confluent_consumer.py", line 8, in <module>
    msg = consumer.poll(1)
KeyboardInterrupt
```

### Related Issues
https://github.com/aws/aws-msk-iam-sasl-signer-python/issues/20

### PR Overview

- [ n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y ] This PR is backwards compatible [y/n]
- [ n ] This PR changes the current API [y/n]
