### PR TITLE
Improve libraries requirements

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,14 @@ To install aws-msk-iam-sasl-signer-python, run this command in your terminal:
 
     $ pip install aws-msk-iam-sasl-signer-python
 
+
+To install the library and use the CLI
+
+.. code-block:: console
+
+    $ pip install aws-msk-iam-sasl-signer-python[console_scripts]
+
+
 This is the preferred method to install aws-msk-iam-sasl-signer-python, as it will always install the most recent stable release.
 
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ with open("README.rst") as readme_file:
 with open("CHANGELOG.rst") as changelog_file:
     history = changelog_file.read()
 
-requirements = ["Click>=7.0", "boto3>=1.26.125", "botocore>=1.29.125"]
+requirements = ["boto3>=1.26,<2.0", "botocore>=1.29,<2.0"]
+cli_requirements = ["Click>=7.0"]
 
 test_requirements = [
     "pytest==7.3.1",
@@ -44,6 +45,9 @@ setup(
         ],
     },
     install_requires=requirements,
+    extras_require={
+        "console_scripts": cli_requirements
+    },
     license="Apache Software License 2.0",
     long_description_content_type="text/x-rst",
     long_description=readme + "\n\n" + history,


### PR DESCRIPTION
Click as a dependency is only required for the CLI. 
The newest version of boto3/botocore do not have a different behaviour on the way it creates the client session.
Allowing newer versions of boto3 and botocore shouldn't be an issue.


### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [y ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y ] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n]
