### PR TITLE
Increasing version to v1.0.1 after expanded dependency constraints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =================
 
+1.0.1 (2024-01-17)
+------------------
+
+* Expanding version dependency constraints
+
 
 1.0.0 (2023-11-09)
 ------------------

--- a/SUPPORT.rst
+++ b/SUPPORT.rst
@@ -13,7 +13,7 @@ Q&A (please complete the following information)
  - OS: [e.g. macOS]
  - Version: [e.g. 22.1.0]
  - Method of installation: [e.g. github]
- - aws-msk-iam-sasl-signer-python version: [e.g. 1.0.0]
+ - aws-msk-iam-sasl-signer-python version: [e.g. 1.0.1]
  - Kafka library name: [e.g. kafka-python]
  - Kafka library version
  - Provide us a sample code snippet of your producer/consumer

--- a/aws_msk_iam_sasl_signer/__init__.py
+++ b/aws_msk_iam_sasl_signer/__init__.py
@@ -2,4 +2,4 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 __author__ = "Amazon Managed Streaming for Apache Kafka"
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/aws/aws-msk-iam-sasl-signer-python",
-    version="1.0.0",
+    version="1.0.1",
     zip_safe=False,
 )


### PR DESCRIPTION
### Summary

I cannot use the v1.26.125 boto3 specific dependency version defined in v1.0.0 due to an dependency graph. It looks like there was a recent change that expands the dependency constraint, but the releases don't include the latest version. Hopefully I've bumped the version correctly; if there's an automated way to do it, I can close out this PR 😄


### Testing Done

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n]
