### PR TITLE
Revert "Improve libraries requirements"

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,14 +14,6 @@ To install aws-msk-iam-sasl-signer-python, run this command in your terminal:
 
     $ pip install aws-msk-iam-sasl-signer-python
 
-
-To install the library and use the CLI
-
-.. code-block:: console
-
-    $ pip install aws-msk-iam-sasl-signer-python[console_scripts]
-
-
 This is the preferred method to install aws-msk-iam-sasl-signer-python, as it will always install the most recent stable release.
 
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ with open("README.rst") as readme_file:
 with open("CHANGELOG.rst") as changelog_file:
     history = changelog_file.read()
 
-requirements = ["boto3>=1.26,<2.0", "botocore>=1.29,<2.0"]
-cli_requirements = ["Click>=7.0"]
+requirements = ["Click>=7.0", "boto3>=1.26.125", "botocore>=1.29.125"]
 
 test_requirements = [
     "pytest==7.3.1",
@@ -45,9 +44,6 @@ setup(
         ],
     },
     install_requires=requirements,
-    extras_require={
-        "console_scripts": cli_requirements
-    },
     license="Apache Software License 2.0",
     long_description_content_type="text/x-rst",
     long_description=readme + "\n\n" + history,


### PR DESCRIPTION
Reverts aws/aws-msk-iam-sasl-signer-python#27

Reverting to ensure tests pass. Failing tests : https://github.com/aws/aws-msk-iam-sasl-signer-python/actions/runs/9258482853